### PR TITLE
Upload AppImage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,12 @@ script:
   - ls -l SER_Player-*.AppImage
 
 after_success:
-  - echo *** Running after_success ***
-  - ls -l
   - find appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
-  - find . -name "*.AppImage"
+  - # curl --upload-file APPNAME*.AppImage https://transfer.sh/APPNAME-git.$(git rev-parse --short HEAD)-x86_64.AppImage
+  - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
+  - bash upload.sh SER_Player*.AppImage*
+  
+branches:
+  except:
+    - # Do not build tags that we create when we upload to GitHub Releases
+    - /^(?i:continuous)/


### PR DESCRIPTION
Upload the AppImage to GitHub Releases.

__PLEASE NOTE:__ For this to work, you need to set up `GITHUB_TOKEN` in Travis CI for this to work; please see https://github.com/probonopd/uploadtool.